### PR TITLE
fix: crash when enable proguard

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,6 +62,8 @@ android {
         }
       }
     }
+
+    consumerProguardFiles 'proguard-rules.pro'
   }
 
   externalNativeBuild {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.margelo.nitro.nitrospeech.** { *; }


### PR DESCRIPTION
### Description

Without this fix, when enabling ProGuard, the application crashes instantly.