### PR TITLE
Add proguard-rules.pro to package.json files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "android/build.gradle",
     "android/gradle.properties",
     "android/fix-prefab.gradle",
+    "android/proguard-rules.pro",
     "android/CMakeLists.txt",
     "android/src",
     "ios/**/*.h",


### PR DESCRIPTION
Without this fix, my previous [PR](https://github.com/NotGeorgeMessier/nitro-speech/pull/1) doesn't work.